### PR TITLE
Improve type coverage of messages.

### DIFF
--- a/src/popup-tab-switcher.ts
+++ b/src/popup-tab-switcher.ts
@@ -9,15 +9,7 @@ import downloadsSymbol from './images/downloads-icon.svg';
 import extensionsSymbol from './images/extensions-icon.svg';
 import historySymbol from './images/history-icon.svg';
 import bookmarksSymbol from './images/bookmarks-icon.svg';
-import {
-  ApplyNewSettingsPayload,
-  ApplyNewSettingsSilentlyPayload,
-  handleMessage,
-  Handlers,
-  Message,
-  SelectTabPayload,
-  switchTab,
-} from './utils/messages';
+import {handleMessage, Handlers, Message, switchTab} from './utils/messages';
 import {DefaultSettings} from './utils/settings';
 
 import Tab = Tabs.Tab;
@@ -179,16 +171,16 @@ export default class PopupTabSwitcher extends HTMLElement {
     this.card.addEventListener('keydown', this.cardEventListener);
     window.addEventListener('blur', this.windowEventListener);
     this.messageListener = handleMessage({
-      [Message.APPLY_NEW_SETTINGS]: ({tabsData, newSettings}: ApplyNewSettingsPayload) => {
+      [Message.APPLY_NEW_SETTINGS]: ({tabsData, newSettings}) => {
         this.tabsArray = tabsData;
         settings = newSettings;
         this.renderTabs();
       },
-      [Message.APPLY_NEW_SETTINGS_SILENTLY]: ({newSettings}: ApplyNewSettingsSilentlyPayload) => {
+      [Message.APPLY_NEW_SETTINGS_SILENTLY]: ({newSettings}) => {
         settings = newSettings;
       },
       [Message.CLOSE_POPUP]: this.hideOverlay,
-      [Message.SELECT_TAB]: ({tabsData, increment}: SelectTabPayload) => {
+      [Message.SELECT_TAB]: ({tabsData, increment}) => {
         this.tabsArray = tabsData;
         this.selectNextTab(increment);
         // When the focus is on the address bar or the 'search in the page' field
@@ -273,11 +265,7 @@ export default class PopupTabSwitcher extends HTMLElement {
 
   switchTo(selectedTab: Tab) {
     this.hideOverlay();
-    contentScriptPort.postMessage(
-      switchTab({
-        selectedTab,
-      })
-    );
+    contentScriptPort.postMessage(switchTab(selectedTab));
   }
 
   getTabElements() {

--- a/src/settings/settings.vue
+++ b/src/settings/settings.vue
@@ -46,7 +46,7 @@
     },
     methods: {
       updateSettings(newSettings) {
-        port.postMessage(updateSettings({newSettings}));
+        port.postMessage(updateSettings(newSettings));
       },
       setDefaults() {
         settingsService.setDefaults();

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -15,64 +15,45 @@ export enum Message {
   COMMAND = 'COMMAND',
 }
 
-interface CommandMessage {
-  type: Message.COMMAND;
-  command: Command;
+export function updateSettings(newSettings: DefaultSettings) {
+  return {type: Message.UPDATE_SETTINGS, newSettings} as const;
+}
+
+export function applyNewSettings(newSettings: DefaultSettings, tabsData: Tab[]) {
+  return {type: Message.APPLY_NEW_SETTINGS, newSettings, tabsData} as const;
+}
+
+export function applyNewSettingsSilently(newSettings: DefaultSettings) {
+  return {type: Message.APPLY_NEW_SETTINGS_SILENTLY, newSettings} as const;
+}
+
+export function switchTab(selectedTab: Tab) {
+  return {type: Message.SWITCH_TAB, selectedTab} as const;
+}
+
+export function selectTab(tabsData: Tab[], increment: number) {
+  return {type: Message.SELECT_TAB, tabsData, increment} as const;
+}
+
+export function closePopup() {
+  return {type: Message.CLOSE_POPUP} as const;
+}
+
+export function command(cmd: Command) {
+  return {type: Message.COMMAND, command: cmd} as const;
 }
 
 export interface Handlers {
   [key: string]: (message?: unknown) => void;
-  [Message.COMMAND]?: (message: CommandMessage) => void;
-}
-
-export interface UpdateSettingsPayload {
-  newSettings: DefaultSettings;
-}
-
-export function updateSettings(payload: UpdateSettingsPayload) {
-  return {type: Message.UPDATE_SETTINGS, ...payload};
-}
-
-export interface ApplyNewSettingsPayload {
-  newSettings: DefaultSettings;
-  tabsData: Tab[];
-}
-
-export function applyNewSettings(payload: ApplyNewSettingsPayload) {
-  return {type: Message.APPLY_NEW_SETTINGS, ...payload};
-}
-
-export interface ApplyNewSettingsSilentlyPayload {
-  newSettings: DefaultSettings;
-}
-
-export function applyNewSettingsSilently(payload: ApplyNewSettingsSilentlyPayload) {
-  return {type: Message.APPLY_NEW_SETTINGS_SILENTLY, ...payload};
-}
-
-export interface SwitchTabPayload {
-  selectedTab: Tab;
-}
-
-export function switchTab(payload: SwitchTabPayload) {
-  return {type: Message.SWITCH_TAB, ...payload};
-}
-
-export interface SelectTabPayload {
-  tabsData: Tab[];
-  increment: number;
-}
-
-export function selectTab(payload: SelectTabPayload) {
-  return {type: Message.SELECT_TAB, ...payload};
-}
-
-export function closePopup() {
-  return {type: Message.CLOSE_POPUP};
-}
-
-export function command(cmd: Command): CommandMessage {
-  return {type: Message.COMMAND, command: cmd};
+  [Message.UPDATE_SETTINGS]?: (message: ReturnType<typeof updateSettings>) => void;
+  [Message.APPLY_NEW_SETTINGS]?: (message: ReturnType<typeof applyNewSettings>) => void;
+  [Message.APPLY_NEW_SETTINGS_SILENTLY]?: (
+    message: ReturnType<typeof applyNewSettingsSilently>
+  ) => void;
+  [Message.SWITCH_TAB]?: (message: ReturnType<typeof switchTab>) => void;
+  [Message.SELECT_TAB]?: (message: ReturnType<typeof selectTab>) => void;
+  [Message.CLOSE_POPUP]?: () => void;
+  [Message.COMMAND]?: (message: ReturnType<typeof command>) => void;
 }
 
 export function handleMessage(handlers: Handlers, typeKey = 'type') {


### PR DESCRIPTION
Reduce the number of interfaces by using 'as const'.
Move mappings between message type and its payload to single place (Handlers interface).