### PR TITLE
Preserve popup look on page zooming

### DIFF
--- a/e2e/settings-e2e.ts
+++ b/e2e/settings-e2e.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import {Browser, Page} from 'puppeteer';
 import {defaultSettings, DefaultSettings} from '../src/utils/settings';
 import {closeTabs, startPuppeteer, stopPuppeteer} from './utils/puppeteer-utils';
-import {PuppeteerPopupHelper} from './utils/puppeteer-popup-helper';
+import {PuppeteerPopupHelper, settingsPageUrl} from './utils/puppeteer-popup-helper';
 
 declare global {
   interface Window {
@@ -12,7 +12,6 @@ declare global {
 
 let browser: Browser;
 let helper: PuppeteerPopupHelper;
-const settingsPageUrl = 'chrome-extension://meonejnmljcnoodabklmloagmnmcmlam/settings/index.html';
 
 async function input(page: Page, selector: string, text: string) {
   await page.evaluate((s) => {
@@ -130,13 +129,9 @@ describe('settings >', function TestSettings() {
     function getSettingsFromContentScript() {
       return ([el]: HTMLElement[]) => {
         const style = window.getComputedStyle(el);
-        const popupWidth = Math.round(
-          Number(style.getPropertyValue('--popup-width-factor')) * window.outerWidth
-        );
-        const tabHeight = Math.round(
-          Number(style.getPropertyValue('--tab-height-factor')) * window.outerWidth
-        );
-        const opacity = Math.round(Number(style.getPropertyValue('--popup-opacity')) * 100);
+        const popupWidth = Number.parseInt(style.getPropertyValue('--popup-width'), 10);
+        const tabHeight = Number.parseInt(style.getPropertyValue('--tab-height'), 10);
+        const opacity = Number.parseFloat(style.getPropertyValue('--popup-opacity')) * 100;
         return {
           popupWidth,
           tabHeight,

--- a/e2e/utils/page-scripts.ts
+++ b/e2e/utils/page-scripts.ts
@@ -3,6 +3,7 @@ declare global {
     e2e: {
       isVisible(el: Element): boolean;
       queryPopup(selector: string): Element[];
+      sendMessage(message: unknown): void;
     };
   }
 }
@@ -65,5 +66,9 @@ export function registerScripts() {
     );
   }
 
-  window.e2e = {isVisible, queryPopup};
+  function sendMessage(message: unknown) {
+    window.dispatchEvent(new CustomEvent('e2e-command-to-background', {detail: message}));
+  }
+
+  window.e2e = {isVisible, queryPopup, sendMessage};
 }

--- a/e2e/utils/puppeteer-config.ts
+++ b/e2e/utils/puppeteer-config.ts
@@ -1,9 +1,10 @@
 // eslint-disable import/prefer-default-export
 import path from 'path';
+import {LaunchOptions} from 'puppeteer';
 
 const pathToExtension = path.join(__dirname, '../../build-e2e');
 
-export default {
+export const config: LaunchOptions = {
   executablePath: process.env.PUPPETEER_EXEC_PATH,
   headless: false,
   slowMo: process.env.CI ? 100 : 20,

--- a/e2e/utils/puppeteer-utils.ts
+++ b/e2e/utils/puppeteer-utils.ts
@@ -1,5 +1,5 @@
 import puppeteer, {Browser} from 'puppeteer';
-import puppeteerConfig from './puppeteer-config';
+import {config} from './puppeteer-config';
 import {PuppeteerPopupHelper} from './puppeteer-popup-helper';
 
 let browser: Browser;
@@ -9,7 +9,7 @@ export async function startPuppeteer() {
   if (browser) {
     return {browser, helper};
   }
-  browser = await puppeteer.launch(puppeteerConfig);
+  browser = await puppeteer.launch(config);
   helper = new PuppeteerPopupHelper(browser);
   return {browser, helper};
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -66,6 +66,9 @@ function initForE2ETests() {
           [Message.COMMAND]: async ({command}) => {
             await handleCommand(command);
           },
+          [Message.E2E_SET_ZOOM]: ({zoomFactor}) => {
+            browser.tabs.setZoom(zoomFactor);
+          },
         })
       );
     }

--- a/src/background.ts
+++ b/src/background.ts
@@ -97,7 +97,11 @@ async function handleCommand(command: Command) {
   // send the command to the content script
   await browser.tabs.sendMessage(
     currentTab.id,
-    selectTab(registry.getTabsToShow(), command === Command.NEXT ? 1 : -1)
+    selectTab(
+      registry.getTabsToShow(),
+      command === Command.NEXT ? 1 : -1,
+      await browser.tabs.getZoom()
+    )
   );
 }
 

--- a/src/e2e-test-commands-bridge.ts
+++ b/src/e2e-test-commands-bridge.ts
@@ -21,11 +21,8 @@ function sendCommandIfShortcutWasPressed({key, altKey, ctrlKey, metaKey, shiftKe
 
 window.addEventListener('keydown', sendCommandIfShortcutWasPressed);
 
-/*
- * Provides a way of updating extension settings from e2e tests.
- */
-// function updateSettings(e: CustomEvent<DefaultSettings>) {
-//   port.postMessage(Messages.updateSettings({newSettings: e.detail}));
-// }
-//
-// window.addEventListener('update-settings', updateSettings);
+function sendCommandToBackground(e: CustomEvent<unknown>) {
+  port.postMessage(e.detail);
+}
+
+window.addEventListener('e2e-command-to-background', sendCommandToBackground);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.7.7",
+  "version": "1.7.8",
   "name": "Popup Tab Switcher",
   "description": "Makes switching between tabs more convenient.",
   "permissions": [

--- a/src/popup-tab-switcher.scss
+++ b/src/popup-tab-switcher.scss
@@ -122,6 +122,9 @@
 .tab__icon {
   height: auto;
   width: var(--icon-size);
+  // Prevents jumping of the icon after image finished loading.
+  // The width property doesn't apply to the image when it is loading.
+  max-width: var(--icon-size);
   fill: var(--tab__icon-fill);
 
   &_noFavIcon {

--- a/src/popup-tab-switcher.scss
+++ b/src/popup-tab-switcher.scss
@@ -2,14 +2,17 @@
 // this BEM naming scheme can be used in JS without quotes
 :host {
   --time-auto-switch-timeout: 500ms;
-  --size-window-width: 0;
-  --popup-height-factor: 0;
-  --popup-width-factor: 0;
-  --popup-border-radius-factor: 0;
-  --tab-height-factor: 0;
-  --font-size-factor: 0;
-  --icon-size-factor: 0;
   --popup-opacity: 1;
+
+  --popup-width: 0;
+  --popup-height: 0;
+  --popup-border-radius: 0;
+  --tab-height: 0;
+  --tab-horizontal-padding: 0;
+  --tab-text-padding: 0;
+  --tab-timeout-indicator-height: 0;
+  --font-size: 0;
+  --icon-size: 0;
 
   display: none;
   position: fixed !important;
@@ -36,18 +39,17 @@
   @include popup-theme-light();
 
   background: var(--card-background-color);
-  border-radius: calc(var(--popup-border-radius-factor) * 100vw);
-  border-left: calc(var(--popup-border-radius-factor) * 100vw) solid;
+  border-radius: var(--popup-border-radius);
+  border-left: var(--popup-border-radius) solid;
   border-left-color: var(--tab_selected-background);
-  padding-right: calc(var(--popup-border-radius-factor) * 100vw);
-  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.2),
-  0 3px 4px rgba(0, 0, 0, 0.12),
-  0 2px 4px rgba(0, 0, 0, 0.14);
+  padding-right: var(--popup-border-radius);
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.2), 0 3px 4px rgba(0, 0, 0, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.14);
   color: var(--card-color);
-  font-size: calc(var(--font-size-factor) * 100vw);
-  height: calc(var(--popup-height-factor) * 100vw);
+  font-size: var(--font-size);
+  height: var(--popup-height);
   max-height: 100%;
-  width: calc(var(--popup-width-factor) * 100vw);
+  width: var(--popup-width);
   max-width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
@@ -60,11 +62,11 @@
 .tab {
   display: flex;
   align-items: center;
-  height: calc(var(--tab-height-factor) * 100vw);
-  padding: 0 calc(10 / var(--size-window-width) * 100vw);
+  height: var(--tab-height);
+  padding: 0 var(--tab-horizontal-padding);
   position: relative;
-  border-bottom-right-radius: calc(var(--popup-border-radius-factor) * 100vw);
-  border-top-right-radius: calc(var(--popup-border-radius-factor) * 100vw);
+  border-bottom-right-radius: var(--popup-border-radius);
+  border-top-right-radius: var(--popup-border-radius);
   outline: none;
   cursor: default;
 
@@ -101,39 +103,39 @@
 
 .tab__cornerIcon {
   position: absolute;
-  width: calc(var(--popup-border-radius-factor) * 100vw);
-  height: calc(var(--popup-border-radius-factor) * 100vw);
+  width: var(--popup-border-radius);
+  height: var(--popup-border-radius);
   fill: var(--card-background-color);
   left: 0;
 
   &_bottom {
-    bottom: calc(-1 * var(--popup-border-radius-factor) * 100vw);
+    bottom: calc(-1 * var(--popup-border-radius)); // TODO: check if it can be replaced with transform
     transform: rotate(90deg);
   }
 
   &_top {
-    top: calc(-1 * var(--popup-border-radius-factor) * 100vw);
+    top: calc(-1 * var(--popup-border-radius)); // TODO: check if it can be replaced with transform
   }
 }
 
 .tab__icon {
   height: auto;
-  width: calc(var(--icon-size-factor) * 100vw);
-  min-width: calc(var(--icon-size-factor) * 100vw);
+  width: var(--icon-size);
+  min-width: var(--icon-size); // TODO: check necessity
   fill: var(--tab__icon-fill);
 
   &_noFavIcon {
-    fill: var(--tab__icon_noFavIcon-fill)
+    fill: var(--tab__icon_noFavIcon-fill);
   }
 }
 
 .tab__text {
   position: relative;
   width: 100%;
-  max-height: calc(var(--tab-height-factor) * 100vw);
+  max-height: var(--tab-height);
   white-space: nowrap;
   overflow: hidden;
-  padding-left: calc(14 / var(--size-window-width) * 100vw);
+  padding-left: var(--tab-text-padding);
 
   &::after {
     --start-color: var(--card-background-color);
@@ -141,7 +143,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    width: calc(14 / var(--size-window-width) * 100vw);
+    width: var(--tab-text-padding);
     height: 100%;
     background: linear-gradient(to left, var(--start-color), transparent);
   }
@@ -150,10 +152,10 @@
 .tab__timeoutIndicator {
   position: absolute;
   width: 95%;
-  height: calc(2 / var(--size-window-width) * 100vw);
+  height: var(--tab-timeout-indicator-height);
   background: var(--tab__timeoutIndicator-background);
   bottom: 0;
-  left: calc(var(--popup-border-radius-factor) * 100vw);
+  left: var(--popup-border-radius);
   animation-name: shrunk-indicator;
   animation-duration: var(--time-auto-switch-timeout);
   animation-timing-function: linear;

--- a/src/popup-tab-switcher.scss
+++ b/src/popup-tab-switcher.scss
@@ -107,21 +107,21 @@
   height: var(--popup-border-radius);
   fill: var(--card-background-color);
   left: 0;
+}
 
-  &_bottom {
-    bottom: calc(-1 * var(--popup-border-radius)); // TODO: check if it can be replaced with transform
-    transform: rotate(90deg);
-  }
+.tab__cornerIcon_bottom {
+  bottom: 0;
+  transform: translateY(100%) rotate(90deg);
+}
 
-  &_top {
-    top: calc(-1 * var(--popup-border-radius)); // TODO: check if it can be replaced with transform
-  }
+.tab__cornerIcon_top {
+  top: 0;
+  transform: translateY(-100%);
 }
 
 .tab__icon {
   height: auto;
   width: var(--icon-size);
-  min-width: var(--icon-size); // TODO: check necessity
   fill: var(--tab__icon-fill);
 
   &_noFavIcon {

--- a/src/popup-tab-switcher.ts
+++ b/src/popup-tab-switcher.ts
@@ -230,23 +230,38 @@ export default class PopupTabSwitcher extends HTMLElement {
   }
 
   showOverlay() {
-    const {tabHeight, popupWidth, fontSize, iconSize, numberOfTabsToShow, opacity} = settings;
-    const popupHeight = numberOfTabsToShow * tabHeight;
-    const popupBorderRadius = 8;
-    this.style.setProperty('--popup-width-factor', `${popupWidth / window.outerWidth}`);
-    this.style.setProperty('--popup-height-factor', `${popupHeight / window.outerWidth}`);
-    this.style.setProperty(
-      '--popup-border-radius-factor',
-      `${popupBorderRadius / window.outerWidth}`
-    );
-    this.style.setProperty('--tab-height-factor', `${tabHeight / window.outerWidth}`);
-    this.style.setProperty('--font-size-factor', `${fontSize / window.outerWidth}`);
-    this.style.setProperty('--icon-size-factor', `${iconSize / window.outerWidth}`);
-    this.style.setProperty('--size-window-width', `${window.outerWidth}`);
-    this.style.setProperty('--popup-opacity', `${opacity / 100}`);
+    this.setStylePropertiesThatDependOnPageZoom();
+    this.style.setProperty('--popup-opacity', `${settings.opacity / 100}`);
     this.style.setProperty('--time-auto-switch-timeout', `${settings.autoSwitchingTimeout}ms`);
     this.style.display = 'block';
     this.isOverlayVisible = true;
+  }
+
+  private setStylePropertiesThatDependOnPageZoom() {
+    /*
+     NOTE:
+     The popup tries to look the same independent of page zoom level.
+     Unfortunately there is no way of getting zoom level reliably (https://stackoverflow.com/questions/1713771/how-to-detect-page-zoom-level-in-all-modern-browsers).
+     - Using outerWidth/innerWidth will give wrong results if a side bar is open (eg. dev tools,
+       menu in FF).
+     - The devicePixelRatio (DPR) changes on zoom but you can't rely on it on high DPI devices
+       because there is no way of getting base DPR that corresponds to zoom 100% (https://www.w3.org/community/respimg/2013/04/06/devicenormalpixelratio-proposal-for-zoom-independent-devicepixelratio-for-hd-retina-games/).
+     - Currently the 'vw' unit is used to preserve popup look on different zoom levels which has
+       the same flaws as outerWidth/innerWidth approach.
+
+     There is also Tab.getZoom() but it is extension specific API.
+    */
+    const {fontSize, numberOfTabsToShow, tabHeight, popupWidth, iconSize} = settings;
+    const {outerWidth} = window;
+    const popupHeight = numberOfTabsToShow * tabHeight;
+    const popupBorderRadius = 8;
+    this.style.setProperty('--popup-width-factor', `${popupWidth / outerWidth}`);
+    this.style.setProperty('--popup-height-factor', `${popupHeight / outerWidth}`);
+    this.style.setProperty('--popup-border-radius-factor', `${popupBorderRadius / outerWidth}`);
+    this.style.setProperty('--tab-height-factor', `${tabHeight / outerWidth}`);
+    this.style.setProperty('--font-size-factor', `${fontSize / outerWidth}`);
+    this.style.setProperty('--icon-size-factor', `${iconSize / outerWidth}`);
+    this.style.setProperty('--size-window-width', `${outerWidth}`);
   }
 
   hideOverlay() {

--- a/src/popup-tab-switcher.ts
+++ b/src/popup-tab-switcher.ts
@@ -53,6 +53,12 @@ function getIconEl(favIconUrl: string, url: string) {
     }
     return createSVGIcon(favIcons.default, 'tab__icon tab__icon_noFavIcon');
   }
+  /*
+   TODO: Sometimes favicons fail to load and ugly placeholder appears.
+   We can improve this with 'onerror' handler. When error occurs:
+    1. Show globe icon.
+    2. Download icon from 'https://www.google.com/s2/favicons?sz=64&domain_url=yahoo.com' and set src to base64 encoded image.
+  */
   iconEl = document.createElement('img');
   iconEl.src = favIconUrl;
   iconEl.className = 'tab__icon';
@@ -264,25 +270,21 @@ export default class PopupTabSwitcher extends HTMLElement {
     const tabTextPadding = 14;
     const tabTimeoutIndicatorHeight = 2;
 
-    const {floor} = Math;
-    this.style.setProperty('--popup-width', `${floor(popupWidth / this.zoomFactor)}px`);
-    this.style.setProperty('--popup-height', `${floor(popupHeight / this.zoomFactor)}px`);
-    this.style.setProperty(
-      '--popup-border-radius',
-      `${floor(popupBorderRadius / this.zoomFactor)}px`
-    );
-    this.style.setProperty('--tab-height', `${floor(tabHeight / this.zoomFactor)}px`);
+    this.style.setProperty('--popup-width', `${popupWidth / this.zoomFactor}px`);
+    this.style.setProperty('--popup-height', `${popupHeight / this.zoomFactor}px`);
+    this.style.setProperty('--popup-border-radius', `${popupBorderRadius / this.zoomFactor}px`);
+    this.style.setProperty('--tab-height', `${tabHeight / this.zoomFactor}px`);
     this.style.setProperty(
       '--tab-horizontal-padding',
-      `${floor(tabHorizontalPadding / this.zoomFactor)}px`
+      `${tabHorizontalPadding / this.zoomFactor}px`
     );
-    this.style.setProperty('--tab-text-padding', `${floor(tabTextPadding / this.zoomFactor)}px`);
+    this.style.setProperty('--tab-text-padding', `${tabTextPadding / this.zoomFactor}px`);
     this.style.setProperty(
       '--tab-timeout-indicator-height',
-      `${floor(tabTimeoutIndicatorHeight / this.zoomFactor)}px`
+      `${tabTimeoutIndicatorHeight / this.zoomFactor}px`
     );
-    this.style.setProperty('--font-size', `${floor(fontSize / this.zoomFactor)}px`);
-    this.style.setProperty('--icon-size', `${floor(iconSize / this.zoomFactor)}px`);
+    this.style.setProperty('--font-size', `${fontSize / this.zoomFactor}px`);
+    this.style.setProperty('--icon-size', `${iconSize / this.zoomFactor}px`);
   }
 
   hideOverlay() {

--- a/src/popup-tab-switcher.ts
+++ b/src/popup-tab-switcher.ts
@@ -181,6 +181,10 @@ export default class PopupTabSwitcher extends HTMLElement {
       [Message.APPLY_NEW_SETTINGS_SILENTLY]: ({newSettings}) => {
         settings = newSettings;
       },
+      [Message.UPDATE_ZOOM_FACTOR]: ({zoomFactor}) => {
+        this.zoomFactor = zoomFactor;
+        this.setStylePropertiesThatDependOnPageZoom();
+      },
       [Message.CLOSE_POPUP]: this.hideOverlay,
       [Message.SELECT_TAB]: ({tabsData, increment, zoomFactor}) => {
         this.tabsArray = tabsData;

--- a/src/popup-tab-switcher.ts
+++ b/src/popup-tab-switcher.ts
@@ -55,9 +55,15 @@ function getIconEl(favIconUrl: string, url: string) {
   }
   /*
    TODO: Sometimes favicons fail to load and ugly placeholder appears.
+   For example the icon of htmlbook.ru doesn't loading on other pages.
    We can improve this with 'onerror' handler. When error occurs:
     1. Show globe icon.
     2. Download icon from 'https://www.google.com/s2/favicons?sz=64&domain_url=yahoo.com' and set src to base64 encoded image.
+   Or this way:
+    1. Show globe icon by default for all images.
+    2. Download original icon. Then show it instead of globe icon.
+    3. If '2' fails, then try to load icon from google service, then show it instead of globe icon.
+    4. If '3' fails leave globe icon as is.
   */
   iconEl = document.createElement('img');
   iconEl.src = favIconUrl;

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -9,6 +9,7 @@ export enum Message {
   APPLY_NEW_SETTINGS = 'APPLY_NEW_SETTINGS',
   APPLY_NEW_SETTINGS_SILENTLY = 'APPLY_NEW_SETTINGS_SILENTLY',
   UPDATE_SETTINGS = 'UPDATE_SETTINGS',
+  UPDATE_ZOOM_FACTOR = 'UPDATE_ZOOM_FACTOR',
   CLOSE_POPUP = 'CLOSE_POPUP',
   SELECT_TAB = 'SELECT_TAB',
   SWITCH_TAB = 'SWITCH_TAB',
@@ -17,6 +18,10 @@ export enum Message {
 
 export function updateSettings(newSettings: DefaultSettings) {
   return {type: Message.UPDATE_SETTINGS, newSettings} as const;
+}
+
+export function updateZoomFactor(zoomFactor: number) {
+  return {type: Message.UPDATE_ZOOM_FACTOR, zoomFactor} as const;
 }
 
 export function applyNewSettings(newSettings: DefaultSettings, tabsData: Tab[]) {
@@ -46,6 +51,7 @@ export function command(cmd: Command) {
 export interface Handlers {
   [key: string]: (message?: unknown) => void;
   [Message.UPDATE_SETTINGS]?: (message: ReturnType<typeof updateSettings>) => void;
+  [Message.UPDATE_ZOOM_FACTOR]?: (message: ReturnType<typeof updateZoomFactor>) => void;
   [Message.APPLY_NEW_SETTINGS]?: (message: ReturnType<typeof applyNewSettings>) => void;
   [Message.APPLY_NEW_SETTINGS_SILENTLY]?: (
     message: ReturnType<typeof applyNewSettingsSilently>

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -14,6 +14,7 @@ export enum Message {
   SELECT_TAB = 'SELECT_TAB',
   SWITCH_TAB = 'SWITCH_TAB',
   COMMAND = 'COMMAND',
+  E2E_SET_ZOOM = 'E2E_SET_ZOOM',
 }
 
 export function updateSettings(newSettings: DefaultSettings) {
@@ -48,6 +49,10 @@ export function command(cmd: Command) {
   return {type: Message.COMMAND, command: cmd} as const;
 }
 
+export function e2eSetZoom(zoomFactor: number) {
+  return {type: Message.E2E_SET_ZOOM, zoomFactor} as const;
+}
+
 export interface Handlers {
   [key: string]: (message?: unknown) => void;
   [Message.UPDATE_SETTINGS]?: (message: ReturnType<typeof updateSettings>) => void;
@@ -60,6 +65,7 @@ export interface Handlers {
   [Message.SELECT_TAB]?: (message: ReturnType<typeof selectTab>) => void;
   [Message.CLOSE_POPUP]?: () => void;
   [Message.COMMAND]?: (message: ReturnType<typeof command>) => void;
+  [Message.E2E_SET_ZOOM]?: (message: ReturnType<typeof e2eSetZoom>) => void;
 }
 
 export function handleMessage(handlers: Handlers, typeKey = 'type') {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -31,8 +31,8 @@ export function switchTab(selectedTab: Tab) {
   return {type: Message.SWITCH_TAB, selectedTab} as const;
 }
 
-export function selectTab(tabsData: Tab[], increment: number) {
-  return {type: Message.SELECT_TAB, tabsData, increment} as const;
+export function selectTab(tabsData: Tab[], increment: number, zoomFactor = 1) {
+  return {type: Message.SELECT_TAB, tabsData, increment, zoomFactor} as const;
 }
 
 export function closePopup() {


### PR DESCRIPTION
The popup tries to look the same independent of a page zoom level.
     Unfortunately there is no way of getting zoom level reliably (https://stackoverflow.com/questions/1713771/how-to-detect-page-zoom-level-in-all-modern-browsers).
     - Using outerWidth/innerWidth will give wrong results if a side bar is open (eg. dev tools,
       menu in FF).
     - The usage of 'vw' unit has the same flaws as outerWidth/innerWidth approach.
     - The window.devicePixelRatio (DPR) changes on zoom but you can't rely on it on high DPI devices
       because there is no way of getting base DPR that corresponds to zoom 100% (https://www.w3.org/community/respimg/2013/04/06/devicenormalpixelratio-proposal-for-zoom-independent-devicepixelratio-for-hd-retina-games/).

Currently extension specific API browser.tabs.getZoom() is used to get tab zoom factor.
Despite of knowing zoom factor the minimal font size on large zoom levels can't be rewritten.