### PR TITLE
Fix error in background on each tab opening

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -163,7 +163,9 @@ async function handleTabRemove(tabId: number) {
 }
 
 function handleZoomChange({tabId, newZoomFactor}: Tabs.OnZoomChangeZoomChangeInfoType) {
-  browser.tabs.sendMessage(tabId, updateZoomFactor(newZoomFactor));
+  if (registry.isInitialized(tabId)) {
+    browser.tabs.sendMessage(tabId, updateZoomFactor(newZoomFactor));
+  }
 }
 
 function handleCommunications(port: Runtime.Port) {
@@ -212,7 +214,7 @@ function handleCommunications(port: Runtime.Port) {
 }
 
 async function initializeContentScript(tab: ITab) {
-  if (!registry.isInitialized(tab)) {
+  if (!registry.isInitialized(tab.id)) {
     const settingsString = settings.getString();
     await browser.tabs.executeScript(tab.id, {
       code: `window.settings = ${settingsString};`,

--- a/src/utils/tab-registry.ts
+++ b/src/utils/tab-registry.ts
@@ -37,8 +37,8 @@ export default class TabRegistry {
     delete this.initializedTabs[tabId];
   }
 
-  isInitialized(tab: ITab) {
-    return this.initializedTabs[tab.id];
+  isInitialized(tabId: number) {
+    return this.initializedTabs[tabId];
   }
 
   push(current: ITab) {


### PR DESCRIPTION
The error was caused by trying to handle zoom change event on new tab opening while the content script was not initialized.