### PR TITLE
Fix the problem with not opening the extension Popup on page with focused iframe and Same-origin policy restrictions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -31,6 +31,7 @@ rules:
   '@typescript-eslint/member-delimiter-style': off
   '@typescript-eslint/no-empty-function': [warn]
   '@typescript-eslint/camelcase': [warn]
+  '@typescript-eslint/no-non-null-assertion': off
   prefer-arrow-callback: off
   object-curly-spacing: [error, never]
   arrow-parens: [error, always]

--- a/e2e/popup.test.ts
+++ b/e2e/popup.test.ts
@@ -74,6 +74,21 @@ describe('popup', function TestPopup() {
       )
       assert.strictEqual(display, 'none', 'The popup is closed')
     })
+
+    it('handles cross-origin iframes gracefully', async () => {
+      // Given a page with a cross-origin iframe and an input field inside the iframe.
+      const page = await helper.openPage('cross-origin-iframe.html')
+
+      // When the iframe input field is focused and the popup is opened and closed.
+      await page.click('iframe')
+      await helper.selectTabForward()
+      await page.isVisible(contentScript.root)
+      await page.keyboard.press('Escape')
+
+      // Then the focus should remain on the iframe input field.
+      const focusedElement = await page.evaluate(() => document.activeElement)
+      assert.strictEqual(await focusedElement?.id, 'iframe-input')
+    })
   })
 
   context('many pages', () => {

--- a/e2e/popup.test.ts
+++ b/e2e/popup.test.ts
@@ -86,8 +86,12 @@ describe('popup', function TestPopup() {
       await page.keyboard.press('Escape')
 
       // Then the focus should remain on the iframe input field.
-      const focusedElement = await page.evaluate(() => document.activeElement)
-      assert.strictEqual(await focusedElement?.id, 'iframe-input')
+      // const focusedElement = await page.evaluate(() => document.activeElement)
+      const isFocusedElementAnIframe = await page.evaluate(() => {
+        const focusedElement = document.activeElement
+        return focusedElement instanceof HTMLIFrameElement
+      })
+      assert.strictEqual(isFocusedElementAnIframe, true, 'The iframe is not focused')
     })
   })
 

--- a/e2e/web-pages/cross-origin-iframe.html
+++ b/e2e/web-pages/cross-origin-iframe.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Page with Cross-Origin Iframe</title>
+  </head>
+  <body>
+    <h1>Page with Cross-Origin Iframe</h1>
+    <iframe name="cross-origin-frame" width="500" height="300" src="https://example.com"> </iframe>
+  </body>
+</html>

--- a/src/content-script/selection-and-focus.ts
+++ b/src/content-script/selection-and-focus.ts
@@ -1,3 +1,5 @@
+import {log} from '../utils/logger'
+
 export class SelectionAndFocus {
   private activeWindow: Window | null
 
@@ -43,7 +45,17 @@ export class SelectionAndFocus {
       return null
     }
     if (activeElement instanceof HTMLIFrameElement && activeElement.contentWindow) {
-      return SelectionAndFocus.getActiveWindow(activeElement.contentWindow)
+      try {
+        // Attempt to access the iframe's contentWindow
+        // This will throw an error if cross-origin access is blocked
+        // eslint-disable-next-line no-unused-expressions
+        activeElement.contentWindow.document // Check if access is allowed
+        return SelectionAndFocus.getActiveWindow(activeElement.contentWindow)
+      } catch (error) {
+        // Cross-origin access is blocked, return the current window
+        log('Cross-origin iframe access blocked:', error)
+        return current
+      }
     }
     return current
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "2024.1",
+  "version": "2024.2",
   "name": "Popup Tab Switcher",
   "description": "Makes switching between tabs more convenient.",
   "permissions": ["activeTab", "favicon", "scripting", "storage", "tabs"],

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,5 +1,6 @@
 import {Command} from './constants'
 import {ISettings} from './settings'
+import {log} from './logger'
 
 type MessageSender = chrome.runtime.MessageSender
 type Port = chrome.runtime.Port
@@ -196,6 +197,7 @@ export function handleMessage(handlers: Partial<IHandlers>) {
       console.error(`There is no handler for the message.type = ${message.type}`, message)
       return
     }
+    log(`[Message received]`, message)
     // @ts-expect-error
     // TODO: How to guarantee correspondence of a message and handler types?
     const response = handler(message, getSender(sender))


### PR DESCRIPTION
Here we fix the problem with not opening the extension Popup when an Iframe with Same-origin policy restrictions contains a focused element.
The extension was trying to get the focused element in the Iframe to restore the focus after the Popup is closed. However, the Iframe was not accessible due to the Same-origin policy restrictions which caused an error and prevented the Popup from opening.

Changes:

- Add e2e test that checks fallback to the current window in case of the Same-origin policy restrictions.
- Handle errors in SelectionAndFocus.getActiveWindow method. In case it faces Same-origin policy restrictions, it should return the current window.